### PR TITLE
Update Autotools build for nettle library (fixes #5)

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -31,7 +31,12 @@ env = {"HOGWEED_LIBS" => "-L$(libdirs[1]) -L$(BinDeps.libdir(nettle)) -lhogweed 
        "NETTLE_LIBS" => "-L$(libdirs[1]) -L$(BinDeps.libdir(nettle)) -lnettle -lgmp",
        "LIBS" => "-lgmp ", "LD_LIBRARY_PATH" => join([libdirs[1];BinDeps.libdir(nettle)],":")}
 
-provides( Sources, URI("http://www.lysator.liu.se/~nisse/archive/nettle-2.7.tar.gz"), nettle )
-provides( BuildProcess, Autotools(lib_dirs = libdirs, include_dirs = includedirs, env = env), nettle )
+provides( Sources, URI("http://www.lysator.liu.se/~nisse/archive/nettle-2.7.1.tar.gz"), nettle )
+provides( BuildProcess,
+          Autotools(lib_dirs = libdirs,
+                    include_dirs = includedirs,
+                    env = env,
+                    configure_options = ["--disable-openssl", "--libdir=$(BinDeps.libdir(nettle))"]),
+          nettle )
 
 @BinDeps.install


### PR DESCRIPTION
- Per the nettle source, openssl is optionally linked against
  for performance testing only; this causes problems on RedHat/CentOS,
  so is disabled here
- On 64-bit CentOS (and possibly other systems), default library
  path for autotools is `usr/lib64`; `BinDeps` only looks in `usr/lib`,
  so here, the default location is overridden to point to `usr/lib`.
  This is probably better handled in `BinDeps`, but fixing here for
  now so `Nettle` can be used.
- Also bump nettle to 2.7.1 (bug fixes)

cc:@loladiro
