### PR TITLE
fix deprecation warning

### DIFF
--- a/src/hash.jl
+++ b/src/hash.jl
@@ -71,12 +71,12 @@ begin
     end
 
     @eval function update!(state::HashState{$name},data)
-      ccall($fptr_update,Void,(Ptr{Void},Csize_t,Ptr{Uint8}),state.ctx,sizeof(data),data)
+      ccall($fptr_update,Void,(Ptr{Void},Csize_t,Ptr{Uint8}),state.ctx,sizeof(data),pointer(data))
     end
 
     @eval function digest!(state::HashState{$name})
       dgst = Array(Uint8,output_size($name))
-      ccall($fptr_digest,Void,(Ptr{Void},Uint32,Ptr{Uint8}),state.ctx,sizeof(dgst),dgst)
+      ccall($fptr_digest,Void,(Ptr{Void},Uint32,Ptr{Uint8}),state.ctx,sizeof(dgst),pointer(dgst))
       dgst
     end
 


### PR DESCRIPTION
When using arrays for `data` instead of strings this explicit conversion is necessary. Fixes

``` jl
WARNING: convert{T}(p::Type{Ptr{T}},a::Array) is deprecated, use convert(p,pointer(a)) instead
```
