### PR TITLE
Use @__FILE__ macro to get package location

### DIFF
--- a/src/Nettle.jl
+++ b/src/Nettle.jl
@@ -1,7 +1,8 @@
 module Nettle
 
-if isfile(joinpath(Pkg.dir("Nettle"),"deps","deps.jl"))
-   include("../deps/deps.jl")
+const depfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
+if isfile(depfile)
+    include(depfile)
 else
     error("Nettle not properly installed. Please run Pkg.build(\"Nettle\")")
 end


### PR DESCRIPTION
Using `Pkg.dir("Nettle")` fails to get Nettle's base path in cases where the package is installed outside the normal package directory (for example, if it's installed system-wide in `<julia>/local/share`). It was suggested [here](https://github.com/JuliaLang/julia/issues/8679#issuecomment-75764753) that using the `@__FILE__` macro to get the package location would be more appropriate in the short term. In the long term, perhaps `Pkg.dir()` will be smarter, or perhaps there will be nicer syntax for this.