### PR TITLE
Fix symbol export

### DIFF
--- a/src/cipher.jl
+++ b/src/cipher.jl
@@ -124,7 +124,7 @@ function cipher_init()
 
     # Finally, export the type we just created
     for sym in [name, name_encrypt, name_decrypt]
-        eval(current_module(), Expr(:toplevel, Expr(:export, sym)))
+        eval(Expr(:export, sym))
     end
 
     cipher_idx += 1

--- a/src/hash.jl
+++ b/src/hash.jl
@@ -53,7 +53,6 @@ function hash_init()
     fptr_update = nh.update
     fptr_digest = nh.digest
 
-
     # First, create the type itself
     @eval immutable $name <: HashAlgorithm; end
 
@@ -93,7 +92,7 @@ function hash_init()
 
     # Finally, export the type we just created
     for sym in [name, name_hash, name_hmac]
-        eval(current_module(), Expr(:toplevel, Expr(:export, sym)))
+        eval(Expr(:export, sym))
     end
 
     hash_idx += 1


### PR DESCRIPTION
This `current_module()` is unecessary and actually points to the wrong module.
The one argument `eval` function will evaluate this in the right module already.

~~Maybe this can be changed to `@eval` as well but haven't tried.~~ Not now, see comment below.

P.S. the missing export breaks `IJulia`
