### PR TITLE
Nettle 3+ compatible

### DIFF
--- a/src/Nettle.jl
+++ b/src/Nettle.jl
@@ -1,5 +1,7 @@
 module Nettle
 
+using Compat
+
 const depfile = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 if isfile(depfile)
     include(depfile)
@@ -10,14 +12,24 @@ include( "hash.jl" )
 include( "hmac.jl" )
 include( "cipher.jl" )
 
+function get_libnettle_version()
+    # Current version (3.1.1) of nettle doesn't provide a runtime API to query
+    # the version. Using the existance of a symbol added in 3.0 to determine
+    # which version is loaded at runtime. See #46 and
+    # http://upstream-tracker.org/versions/nettle.html
+    hdl = @compat Libdl.dlopen_e(nettle)
+    @compat(Libdl.dlsym_e(hdl, :nettle_aes192_invert_key)) == C_NULL ? 2 : 3
+end
+
 function __init__()
-	hash_init()
-	cipher_init()
+    global const nettle_major_version = get_libnettle_version()
+    hash_init()
+    cipher_init()
 end
 
 # Only manually call __init__() on old versions of Julia
 if VERSION < v"0.3-"
-	__init__()
+    __init__()
 end
 
 # similar to Python's hmac.HMAC.hexdigest

--- a/src/cipher.jl
+++ b/src/cipher.jl
@@ -75,14 +75,26 @@ function cipher_init()
     @eval function CipherEncrypt(::Type{$name},key::Union(String,Vector{Uint8}))
         length(key) != key_size($name) && error("Key must be $(key_size($name)) bytes long")
         ctx = Array(Uint8, ctx_size($name))
-        ccall($fptr_set_encrypt_key,Void,(Ptr{Void},Cuint,Ptr{Uint8}),ctx,length(key),pointer(key))
+        if nettle_major_version >= 3
+            ccall($fptr_set_encrypt_key, Void, (Ptr{Void}, Ptr{Uint8}),
+                  ctx, pointer(key))
+        else
+            ccall($fptr_set_encrypt_key, Void, (Ptr{Void}, Cuint, Ptr{Uint8}),
+                  ctx, length(key), pointer(key))
+        end
         CipherEncrypt{$name}(ctx)
     end
 
     @eval function CipherDecrypt(::Type{$name},key::Union(String,Vector{Uint8}))
         length(key) != key_size($name) && error("Key must be $(key_size($name)) bytes long")
         ctx = Array(Uint8, ctx_size($name))
-        ccall($fptr_set_decrypt_key,Void,(Ptr{Void},Cuint,Ptr{Uint8}),ctx,length(key),pointer(key))
+        if nettle_major_version >= 3
+            ccall($fptr_set_decrypt_key, Void, (Ptr{Void}, Ptr{Uint8}),
+                  ctx, pointer(key))
+        else
+            ccall($fptr_set_decrypt_key, Void, (Ptr{Void}, Cuint, Ptr{Uint8}),
+                  ctx, length(key), pointer(key))
+        end
         CipherDecrypt{$name}(ctx)
     end
 


### PR DESCRIPTION
This fixes #44.

Since I cannot find a way to check reliably at runtime the version check is only done at compile time. This should be good enough for most purpose.
