### PR TITLE
Enable 0.3 and 0.4 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
     - osx
     - linux
 julia:
-    - release
+    - 0.3
+    - 0.4
     - nightly
 notifications:
     email: false


### PR DESCRIPTION
#53 on the sf/breakageahoy branch.