### PR TITLE
change windows library name and alias

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,11 +3,11 @@ using Compat
 
 @BinDeps.setup
 
-nettle = library_dependency("nettle", aliases = ["libnettle","libnettle-4-6"])
+nettle = library_dependency("nettle", aliases = ["libnettle","libnettle-4-6","libnettle-6-1"])
 
 @windows_only begin
   using WinRPM
-  provides(WinRPM.RPM, "libnettle-4-6", nettle, os = :Windows )
+  provides(WinRPM.RPM, "libnettle-6-1", nettle, os = :Windows )
 end
 
 @osx_only begin


### PR DESCRIPTION
The upstream opensuse source for the winrpm binary has changed to libnettle 3.1.1, see https://build.opensuse.org/package/rdiff/windows:mingw:win64/mingw64-libnettle?linkrev=base&rev=12

I don't know whether this breaks the API in a way we need to care about here. Let's see what AppVeyor has to say.