### PR TITLE
Apt-Get --> errors on non-debian systems

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -15,7 +15,7 @@ if is_apple()
   provides( Homebrew.HB, "nettle", nettle, os = :Darwin )
 end
 
-provides( AptGet, "libnettle4", nettle )
+provides( Yum, "libnettle4", nettle )
 provides( Yum, "nettle", nettle )
 
 julia_usrdir = normpath(JULIA_HOME*"/../") # This is a stopgap, we need a better built-in solution to get the included libraries


### PR DESCRIPTION
When opening an issue, please ping `@staticfloat`.

He does not receive emails automatically when new issues are created.
Without this ping, your issue may slip through the cracks!
If no response is garnered within a week, feel free to ping again.

I don't know whether this is maybe an issue with BinDeps. Just FYI I had to make this change on my (Fedora 25) Workstation.